### PR TITLE
Fixes IE support

### DIFF
--- a/src/Elm/Kernel/File.js
+++ b/src/Elm/Kernel/File.js
@@ -15,7 +15,7 @@ import Time exposing (millisToPosix)
 
 var _File_decoder = __Json_decodePrim(function(value) {
 	// NOTE: checks if `File` exists in case this is run on node
-	return (typeof File === 'function' && value instanceof File)
+	return (typeof File !== 'undefined' && value instanceof File)
 		? __Result_Ok(value)
 		: __Json_expecting('a FILE', value);
 });


### PR DESCRIPTION
The defensive check for node.js support causes IE to break. This MR updates File constructor test.

IE doesn't support the File constructor, but it does support the File API. In IE, `typeof File` evaluates to `"object"`.

This broke our app when we upgraded to latest versions.

Fixes: https://github.com/elm/file/issues/8