### PR TITLE
Fix Download.url in IE

### DIFF
--- a/src/Elm/Kernel/File.js
+++ b/src/Elm/Kernel/File.js
@@ -39,11 +39,32 @@ var _File_downloadNode;
 
 function _File_getDownloadNode()
 {
-	return _File_downloadNode || (_File_downloadNode = document.createElement('a'));
+  if (!_File_downloadNode) 
+  {
+    _File_downloadNode = document.createElement('a');
+
+    // for events to work in IE, the trigger element must be attached to the visible DOM
+    document.body.appendChild(_File_downloadNode)
+  }
+  
+  return _File_downloadNode;
 }
 
-var _File_download = F3(function(name, mime, content)
+function _File_createMouseEvent() 
 {
+  if (typeof MouseEvent === 'function') 
+  {
+    return new MouseEvent('click')
+  } 
+  
+  var ev = document.createEvent("MouseEvent");
+  ev.initMouseEvent("click",true,true,window,0,0,0,0,0,false,false,false,false,0,null);
+  return ev;
+  
+}
+
+var _File_download = F3(function(name, mime, content){
+
 	return __Scheduler_binding(function(callback)
 	{
 		var blob = new Blob([content], {type: mime});
@@ -60,7 +81,7 @@ var _File_download = F3(function(name, mime, content)
 		var objectUrl = URL.createObjectURL(blob);
 		node.setAttribute('href', objectUrl);
 		node.setAttribute('download', name);
-		node.dispatchEvent(new MouseEvent('click'));
+		node.dispatchEvent(_File_createMouseEvent());
 		URL.revokeObjectURL(objectUrl);
 	});
 });
@@ -72,7 +93,7 @@ function _File_downloadUrl(href)
 		var node = _File_getDownloadNode();
 		node.setAttribute('href', href);
 		node.setAttribute('download', '');
-		node.dispatchEvent(new MouseEvent('click'));
+		node.dispatchEvent(_File_createMouseEvent());
 	});
 }
 


### PR DESCRIPTION
Fixes https://github.com/elm/file/issues/11

* updates MouseEvent creation to support IE. 
* attaches the node to visible DOM so that the event is dispatched by the browser

This uses `typeof MouseEvent` for capability detection to determine whether we are in IE and 

1. need to use the alternate way of creating the mouse event. 
2. need to append the trigger node to the visible DOM

### Concern 
We probably need to test a few different application types to ensure that Elm's diff/patch doesn't remove this DOM node from the body. AFAIK, there is not an alternative to attaching to the visible DOM to get this event to fire. 

If the DOM node can be removed, then the cached node at (var _File_downloadNode) might need to be re-attached on every download execution or we might just wanna generate a new node each time. 


