### PR TITLE
Allow multiple files upload

### DIFF
--- a/src/Elm/Kernel/File.js
+++ b/src/Elm/Kernel/File.js
@@ -133,7 +133,7 @@ function _File_uploadOneOrMore(mimes)
 	{
 		_File_node = document.createElement('input');
 		_File_node.type = 'file';
-		_File_node.multiple = '';
+		_File_node.multiple = true;
 		_File_node.accept = A2(__String_join, ',', mimes);
 		_File_node.addEventListener('change', function(event)
 		{


### PR DESCRIPTION
A little fix to allow multiples files selection on the file dialog.
With that fix the `multiple` attribute should added correctly to the file input element.