### PR TITLE
Fix for File.lastModified on IE10 and IE11

### DIFF
--- a/src/Elm/Kernel/File.js
+++ b/src/Elm/Kernel/File.js
@@ -29,7 +29,8 @@ function _File_size(file) { return file.size; }
 
 function _File_lastModified(file)
 {
-	return __Time_millisToPosix(file.lastModified);
+	// IE10 and IE11 don't support lastModified, but have lastModifiedDate
+	return __Time_millisToPosix(file.lastModified || file.lastModifiedDate);
 }
 
 


### PR DESCRIPTION
IE11 does not have [`lastModified`](https://developer.mozilla.org/en-US/docs/Web/API/File/lastModified#Browser_compatibility) so we fall back on [`lastModifiedDate`](https://developer.mozilla.org/en-US/docs/Web/API/File/lastModifiedDate).

Note that lastModifiedDate returns a date-object and not an integer, but the time library 
handles this correctly. Alternatively one could do `file.lastModifiedDate.getTime()` to extract
time as in integer.

