### PR TITLE
Fix File.decoder for IE11

### DIFF
--- a/src/Elm/Kernel/File.js
+++ b/src/Elm/Kernel/File.js
@@ -15,7 +15,11 @@ import Time exposing (millisToPosix)
 
 var _File_decoder = __Json_decodePrim(function(value) {
 	// NOTE: checks if `File` exists in case this is run on node
-	return (typeof File !== 'undefined' && value instanceof File)
+	// IE10 and IE11 events contain `File`-like `Blob`s
+	return (
+		(typeof File !== 'undefined' && value instanceof File) ||
+		(typeof Blob !== 'undefined' && value instanceof Blob && value.name)
+	)
 		? __Result_Ok(value)
 		: __Json_expecting('a FILE', value);
 });


### PR DESCRIPTION
IE10 and IE11 events contain `File`-like `Blob`s that don't match `instanceof File`. 
Instead allow `Blob`s with sufficient properties (i.e having the property `name`).

Can be tested by dropping a file in this example using IE11: https://ellie-app.com/3T5mNms7SwKa1