### PR TITLE
upgrade examples to 0.19.1

### DIFF
--- a/examples/DragAndDrop.elm
+++ b/examples/DragAndDrop.elm
@@ -1,3 +1,5 @@
+module DragAndDrop exposing (..)
+
 import Browser
 import File exposing (File)
 import File.Select as Select

--- a/examples/DragAndDropWithImagePreview.elm
+++ b/examples/DragAndDropWithImagePreview.elm
@@ -1,3 +1,5 @@
+module  DragAndDropWithImagePreview exposing (..)
+
 import Browser
 import File exposing (File)
 import File.Select as Select

--- a/examples/SelectFiles.elm
+++ b/examples/SelectFiles.elm
@@ -1,3 +1,5 @@
+module SelectFiles exposing (..)
+
 import Browser
 import File exposing (File)
 import Html exposing (..)

--- a/examples/SelectFilesWithProgress.elm
+++ b/examples/SelectFilesWithProgress.elm
@@ -1,3 +1,5 @@
+module SelectFilesWithProgress exposing (..)
+
 import Browser
 import File exposing (File)
 import Html exposing (..)

--- a/examples/SelectFilesWithProgressAndCancellation.elm
+++ b/examples/SelectFilesWithProgressAndCancellation.elm
@@ -1,3 +1,5 @@
+module SelectFilesWithProgressAndCancellation exposing (..)
+
 import Browser
 import File exposing (File)
 import Html exposing (..)

--- a/examples/elm.json
+++ b/examples/elm.json
@@ -3,7 +3,7 @@
     "source-directories": [
         "."
     ],
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
             "elm/browser": "1.0.1",


### PR DESCRIPTION
I wanted to see the UI for the upload examples, but they're still on 0.19.0.  Updated to 0.19.1 and the examples seem to work fine, just had to add `module` statements. 